### PR TITLE
feat: Introduce API Keys

### DIFF
--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -34,4 +34,14 @@ class ApiKey extends Model
             }
         });
     }
+
+    public function canWrite(): bool
+    {
+        return !$this->read_only;
+    }
+
+    public function recordUsage(): void
+    {
+        $this->update(['last_used_at' => now()]);
+    }
 }

--- a/app/Models/ApiKey.php
+++ b/app/Models/ApiKey.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class ApiKey extends Model
+{
+    use HasFactory;
+
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    protected $fillable = [
+        'name',
+        'read_only',
+        'last_used_at',
+    ];
+
+    protected $casts = [
+        'read_only' => 'boolean',
+        'last_used_at' => 'datetime',
+    ];
+
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::creating(function ($model) {
+            if (!$model->id) {
+                $model->id = (string) Str::uuid();
+            }
+        });
+    }
+}

--- a/database/migrations/2026_01_23_083031_create_api_keys_table.php
+++ b/database/migrations/2026_01_23_083031_create_api_keys_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('api_keys', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->boolean('read_only')->default(true);
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('api_keys');
+    }
+};


### PR DESCRIPTION
## Summary by Sourcery

Add a new API key domain model and database schema to persist API keys with metadata such as name, read-only flag, and last used timestamp.

New Features:
- Introduce an ApiKey Eloquent model representing API keys with UUID identifiers and basic metadata.
- Create a database migration to add an api_keys table storing API key records with read-only status and usage tracking.