### PR TITLE
fix: Adjust buffer time for pre-event reminders

### DIFF
--- a/app/Jobs/SendPreEventReminders.php
+++ b/app/Jobs/SendPreEventReminders.php
@@ -24,10 +24,10 @@ class SendPreEventReminders implements ShouldQueue
     {
         Log::info('Starting pre-event reminder checks');
 
-        // Get the time window: 2 hours from now (with 5 minute buffer)
+        // Get the time window: 2 hours from now (with 3 minute buffer)
         $targetTime = now()->addHours(2);
-        $bufferStart = $targetTime->copy()->subMinutes(5);
-        $bufferEnd = $targetTime->copy()->addMinutes(5);
+        $bufferStart = $targetTime->copy()->subMinutes(3);
+        $bufferEnd = $targetTime->copy()->addMinutes(3);
 
         // Get all upcoming events (both one-time and recurring)
         $events = Event::where('start_datetime', '>=', now())


### PR DESCRIPTION
Send pre event reminders are run every 5 minutes, thus having a 5 minute buffer will cause the event to be reported starting in 2 hours too early

## Summary by Sourcery

Bug Fixes:
- Correct the pre-event reminder buffer from 5 minutes to 3 minutes to prevent reminders from being triggered too early.