### PR TITLE
Fix: Automatic event staffing resets

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -18,9 +18,7 @@ class ApiController extends Controller
     public function __construct(
         protected ControlCenterService $controlCenterService,
         protected RecurringEventService $recurringEventService
-    )
-    {
-    }
+    ) {}
 
     /**
      * Get all events (with optional staffing filter)
@@ -76,7 +74,7 @@ class ApiController extends Controller
                 10,
                 $event->cancelled_occurrences ?? []
             );
-            
+
             $nextOccurrence = collect($instances)->first(fn($instance) => $instance['start']->isFuture());
             $targetOccurrenceDate = $nextOccurrence ? $nextOccurrence['start'] : $event->start_datetime;
         } else {
@@ -98,14 +96,14 @@ class ApiController extends Controller
                         // Combine occurrence date + position time for full datetime
                         $startDatetime = null;
                         $endDatetime = null;
-                        
+
                         if ($position->start_time) {
                             $startDatetime = \Carbon\Carbon::parse($targetOccurrenceDate->format('Y-m-d') . ' ' . $position->start_time);
                         }
                         if ($position->end_time) {
                             $endDatetime = \Carbon\Carbon::parse($targetOccurrenceDate->format('Y-m-d') . ' ' . $position->end_time);
                         }
-                        
+
                         return [
                             'id' => $position->id,
                             'callsign' => $position->position_id,
@@ -134,7 +132,6 @@ class ApiController extends Controller
      */
     public function getAllStaffings()
     {
-        // Get all events that have both a discord channel and message configured
         $events = Event::whereNotNull('discord_staffing_channel_id')
             ->whereNotNull('discord_staffing_message_id')
             ->with(['staffings.positions.bookedBy'])
@@ -143,35 +140,52 @@ class ApiController extends Controller
         $result = [];
         foreach ($events as $event) {
             $firstStaffing = $event->staffings()->with('positions.bookedBy')->orderBy('order')->first();
-            if ($firstStaffing) {
-                $allStaffings = $event->staffings()->with('positions.bookedBy')->orderBy('order')->get();
+            if (!$firstStaffing) continue;
 
-                // Build section titles
-                $sectionTitles = [];
-                foreach ($allStaffings as $index => $section) {
-                    $sectionNumber = $index + 1;
-                    if ($sectionNumber <= 4) {
-                        $sectionTitles["section_{$sectionNumber}_title"] = $section->name;
-                    }
-                }
-                for ($i = count($allStaffings) + 1; $i <= 4; $i++) {
-                    $sectionTitles["section_{$i}_title"] = null;
-                }
+            // Calculate next occurrence date, same as getStaffing()
+            if ($event->isRecurring()) {
+                $instances = $this->recurringEventService->generateInstances(
+                    $event->recurrence_rule,
+                    $event->start_datetime,
+                    now()->addMonths(3),
+                    10,
+                    $event->cancelled_occurrences ?? []
+                );
 
-                $result[] = [
-                    'id' => $firstStaffing->id,
-                    'channel_id' => (int)$event->discord_staffing_channel_id,
-                    'message_id' => $event->discord_staffing_message_id,
-                    'event_id' => $event->id,
-                    ...$sectionTitles,
-                    'event' => [
-                        'id' => $event->id,
-                        'title' => $event->title,
-                        'start_date' => $event->start_datetime->format('Y-m-d H:i:s'),
-                        'end_date' => $event->end_datetime->format('Y-m-d H:i:s'),
-                    ],
-                ];
+                $nextOccurrence = collect($instances)->first(fn($instance) => $instance['start']->isFuture());
+                $targetOccurrenceDate = $nextOccurrence ? $nextOccurrence['start'] : $event->start_datetime;
+            } else {
+                $targetOccurrenceDate = $event->start_datetime;
             }
+
+            $allStaffings = $event->staffings()->with('positions.bookedBy')->orderBy('order')->get();
+
+            $sectionTitles = [];
+            foreach ($allStaffings as $index => $section) {
+                $sectionNumber = $index + 1;
+                if ($sectionNumber <= 4) {
+                    $sectionTitles["section_{$sectionNumber}_title"] = $section->name;
+                }
+            }
+            for ($i = count($allStaffings) + 1; $i <= 4; $i++) {
+                $sectionTitles["section_{$i}_title"] = null;
+            }
+
+            $result[] = [
+                'id'         => $firstStaffing->id,
+                'channel_id' => (int) $event->discord_staffing_channel_id,
+                'message_id' => $event->discord_staffing_message_id,
+                'event_id'   => $event->id,
+                ...$sectionTitles,
+                'event' => [
+                    'id'         => $event->id,
+                    'title'      => $event->title,
+                    'start_date' => $targetOccurrenceDate->format('Y-m-d H:i:s'),
+                    'end_date'   => $targetOccurrenceDate->copy()
+                        ->setTimeFrom($event->end_datetime)
+                        ->format('Y-m-d H:i:s'),
+                ],
+            ];
         }
 
         return response()->json(['data' => $result]);
@@ -184,20 +198,20 @@ class ApiController extends Controller
     public function getStaffingByMessageId(Request $request)
     {
         $messageId = $request->query('message_id');
-        
+
         if (!$messageId) {
             return response()->json(['error' => 'message_id parameter required'], 400);
         }
 
         $event = Event::where('discord_staffing_message_id', $messageId)->first();
-        
+
         if (!$event) {
             return response()->json(['error' => 'Staffing not found'], 404);
         }
 
         // Get the first staffing (we'll return all staffings in the response)
         $staffing = $event->staffings()->with(['positions.bookedBy'])->orderBy('order')->first();
-        
+
         if (!$staffing) {
             return response()->json(['error' => 'No staffing sections found'], 404);
         }
@@ -225,7 +239,7 @@ class ApiController extends Controller
                 10,
                 $event->cancelled_occurrences ?? []
             );
-            
+
             $nextOccurrence = collect($instances)->first(fn($instance) => $instance['start']->isFuture());
             $targetOccurrenceDate = $nextOccurrence ? $nextOccurrence['start'] : $event->start_datetime;
         } else {
@@ -256,14 +270,14 @@ class ApiController extends Controller
                 // Combine occurrence date + position time (if position has specific times)
                 $startTime = null;
                 $endTime = null;
-                
+
                 if ($position->start_time) {
                     $startTime = substr($position->start_time, 0, 5); // "18:00" from "18:00:00"
                 }
                 if ($position->end_time) {
                     $endTime = substr($position->end_time, 0, 5);
                 }
-                
+
                 $allPositions[] = [
                     'id' => $position->id,
                     'callsign' => $position->position_id,
@@ -299,18 +313,20 @@ class ApiController extends Controller
                 'updated_at' => $staffing->updated_at->toIso8601String(),
                 'positions' => $allPositions,
                 'event' => [
-                    'id' => $event->id,
-                    'calendar_id' => $event->calendar_id,
-                    'title' => $event->title,
+                    'id'                => $event->id,
+                    'calendar_id'       => $event->calendar_id,
+                    'title'             => $event->title,
                     'short_description' => $event->short_description,
-                    'long_description' => $event->long_description,
-                    'start_date' => $event->start_datetime->format('Y-m-d H:i:s'),
-                    'end_date' => $event->end_datetime->format('Y-m-d H:i:s'),
-                    'published' => 1,
-                    'image' => $event->banner_path,
-                    'user_id' => $event->created_by,
-                    'created_at' => $event->created_at->toIso8601String(),
-                    'updated_at' => $event->updated_at->toIso8601String(),
+                    'long_description'  => $event->long_description,
+                    'start_date'        => $targetOccurrenceDate->format('Y-m-d H:i:s'),
+                    'end_date'          => $targetOccurrenceDate->copy()
+                        ->setTimeFrom($event->end_datetime)
+                        ->format('Y-m-d H:i:s'),
+                    'published'         => 1,
+                    'image'             => $event->banner_path,
+                    'user_id'           => $event->created_by,
+                    'created_at'        => $event->created_at->toIso8601String(),
+                    'updated_at'        => $event->updated_at->toIso8601String(),
                 ],
             ],
         ]);
@@ -327,7 +343,7 @@ class ApiController extends Controller
         ]);
 
         $staffing = \App\Models\Staffing::with('event')->findOrFail($id);
-        
+
         // Update the event's discord_staffing_message_id
         $staffing->event->update([
             'discord_staffing_message_id' => $validated['message_id'],
@@ -357,7 +373,7 @@ class ApiController extends Controller
 
         // Find staffing by Discord message ID
         $event = \App\Models\Event::where('discord_staffing_message_id', $validated['message_id'])->first();
-        
+
         if (!$event) {
             \Log::error('Event not found for message_id: ' . $validated['message_id']);
             return response()->json(['error' => 'Staffing not found'], 404);
@@ -366,19 +382,19 @@ class ApiController extends Controller
         \Log::info('Found event', ['event_id' => $event->id, 'title' => $event->title]);
 
         // Find the position by callsign
-        $query = \App\Models\StaffingPosition::whereHas('staffing', function($q) use ($event) {
+        $query = \App\Models\StaffingPosition::whereHas('staffing', function ($q) use ($event) {
             $q->where('event_id', $event->id);
         })->where('position_id', $validated['position']);
 
         // If section specified, match by staffing's position in the ordered list
         if (isset($validated['section'])) {
             \Log::info('Section specified', ['section' => $validated['section']]);
-            
+
             // Get all staffings ordered
             $staffings = $event->staffings()->orderBy('order')->get();
-            
+
             \Log::info('Found staffings', ['count' => $staffings->count()]);
-            
+
             // Find the staffing at the specified section position (1-indexed)
             if (isset($staffings[$validated['section'] - 1])) {
                 $targetStaffing = $staffings[$validated['section'] - 1];
@@ -389,12 +405,12 @@ class ApiController extends Controller
                 return response()->json(['error' => 'Section not found'], 404);
             }
         }
-        
+
         // Debug: Log the SQL query
         \Log::info('Query SQL', ['sql' => $query->toSql(), 'bindings' => $query->getBindings()]);
 
         $position = $query->first();
-        
+
         if ($position) {
             \Log::info('Position found!', ['position_id' => $position->id]);
         }
@@ -417,7 +433,7 @@ class ApiController extends Controller
         // Create booking in Control Center
         // Calculate the target occurrence date
         $targetOccurrenceDate = null;
-        
+
         if ($event->isRecurring()) {
             // For recurring events, find next future occurrence
             $instances = $this->recurringEventService->generateInstances(
@@ -427,9 +443,9 @@ class ApiController extends Controller
                 10,
                 $event->cancelled_occurrences ?? []
             );
-            
+
             $nextOccurrence = collect($instances)->first(fn($instance) => $instance['start']->isFuture());
-            
+
             if ($nextOccurrence) {
                 $targetOccurrenceDate = $nextOccurrence['start'];
             } else {
@@ -440,7 +456,7 @@ class ApiController extends Controller
             // Non-recurring event, use event date directly
             $targetOccurrenceDate = $event->start_datetime;
         }
-        
+
         // Combine occurrence date with position time (or event time if position time not set)
         // Position times are now stored as TIME only (e.g., "18:00:00")
         if ($position->start_time && $position->end_time) {
@@ -452,7 +468,7 @@ class ApiController extends Controller
             $startDatetime = $targetOccurrenceDate;
             $endDatetime = $targetOccurrenceDate->copy()->setTimeFrom($event->end_datetime);
         }
-        
+
         $bookingData = [
             'cid' => $validated['cid'],
             'date' => $startDatetime->format('d/m/Y'),
@@ -474,7 +490,7 @@ class ApiController extends Controller
         ]);
 
         $bookingId = $this->controlCenterService->createBooking($bookingData);
-        
+
         // Store Control Center booking ID if successful
         if ($bookingId) {
             $position->update(['control_center_booking_id' => $bookingId]);
@@ -503,17 +519,17 @@ class ApiController extends Controller
 
         // Find staffing by Discord message ID
         $event = \App\Models\Event::where('discord_staffing_message_id', $validated['message_id'])->first();
-        
+
         if (!$event) {
             return response()->json(['error' => 'Staffing not found'], 404);
         }
 
         // Build query to find booked positions (check both user bookings and Discord bookings)
-        $query = \App\Models\StaffingPosition::whereHas('staffing', function($q) use ($event) {
+        $query = \App\Models\StaffingPosition::whereHas('staffing', function ($q) use ($event) {
             $q->where('event_id', $event->id);
-        })->where(function($q) {
+        })->where(function ($q) {
             $q->whereNotNull('booked_by_user_id')
-              ->orWhereNotNull('vatsim_cid');
+                ->orWhereNotNull('vatsim_cid');
         });
 
         if (isset($validated['position'])) {
@@ -523,7 +539,7 @@ class ApiController extends Controller
         if (isset($validated['section'])) {
             // Get all staffings ordered
             $staffings = $event->staffings()->orderBy('order')->get();
-            
+
             // Find the staffing at the specified section position (1-indexed)
             if (isset($staffings[$validated['section'] - 1])) {
                 $targetStaffing = $staffings[$validated['section'] - 1];
@@ -547,7 +563,7 @@ class ApiController extends Controller
             if ($position->control_center_booking_id) {
                 $this->controlCenterService->deleteBooking($position->control_center_booking_id);
             }
-            
+
             $position->update([
                 'booked_by_user_id' => null,
                 'discord_user_id' => null,

--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -64,51 +64,34 @@ class ApiController extends Controller
     {
         $event = Event::with(['calendar', 'staffings.positions.bookedBy'])->findOrFail($id);
 
-        // Calculate target occurrence date for position times
-        $targetOccurrenceDate = null;
-        if ($event->isRecurring()) {
-            $instances = $this->recurringEventService->generateInstances(
-                $event->recurrence_rule,
-                $event->start_datetime,
-                now()->addMonths(3),
-                10,
-                $event->cancelled_occurrences ?? []
-            );
-
-            $nextOccurrence = collect($instances)->first(fn($instance) => $instance['start']->isFuture());
-            $targetOccurrenceDate = $nextOccurrence ? $nextOccurrence['start'] : $event->start_datetime;
-        } else {
-            $targetOccurrenceDate = $event->start_datetime;
-        }
+        $targetOccurrenceDate = $this->resolveTargetOccurrenceDate($event);
 
         return response()->json([
             'event_id' => $event->id,
             'title' => $event->title,
-            'channel_id' => $event->discord_staffing_channel_id, // Bot expects 'channel_id'
-            'message_id' => $event->discord_staffing_message_id, // Bot expects 'message_id'
-            'discord_channel_id' => $event->discord_staffing_channel_id, // Keep for compatibility
-            'discord_message_id' => $event->discord_staffing_message_id, // Keep for compatibility
-            'staffing' => $event->staffings->map(function ($staffing) use ($targetOccurrenceDate, $event) {
+            'channel_id' => $event->discord_staffing_channel_id,
+            'message_id' => $event->discord_staffing_message_id,
+            'discord_channel_id' => $event->discord_staffing_channel_id,
+            'discord_message_id' => $event->discord_staffing_message_id,
+            'staffing' => $event->staffings->map(function ($staffing) use ($targetOccurrenceDate) {
                 return [
                     'id' => $staffing->id,
                     'name' => $staffing->name,
-                    'positions' => $staffing->positions->sortBy('order')->map(function ($position) use ($targetOccurrenceDate, $event) {
-                        // Combine occurrence date + position time for full datetime
+                    'positions' => $staffing->positions->sortBy('order')->map(function ($position) use ($targetOccurrenceDate) {
                         $startDatetime = null;
                         $endDatetime = null;
 
                         if ($position->start_time) {
-                            $startDatetime = \Carbon\Carbon::parse($targetOccurrenceDate->format('Y-m-d') . ' ' . $position->start_time);
+                            $startDatetime = Carbon::parse($targetOccurrenceDate->format('Y-m-d') . ' ' . $position->start_time);
                         }
                         if ($position->end_time) {
-                            $endDatetime = \Carbon\Carbon::parse($targetOccurrenceDate->format('Y-m-d') . ' ' . $position->end_time);
+                            $endDatetime = Carbon::parse($targetOccurrenceDate->format('Y-m-d') . ' ' . $position->end_time);
                         }
 
                         return [
                             'id' => $position->id,
                             'callsign' => $position->position_id,
                             'name' => $position->position_name,
-                            // Send full datetime to bot (calculated from occurrence + position time)
                             'start_time' => $startDatetime ? $startDatetime->format('H:i') : null,
                             'end_time' => $endDatetime ? $endDatetime->format('H:i') : null,
                             'booked' => $position->isBooked(),
@@ -142,34 +125,11 @@ class ApiController extends Controller
             $firstStaffing = $event->staffings()->with('positions.bookedBy')->orderBy('order')->first();
             if (!$firstStaffing) continue;
 
-            // Calculate next occurrence date, same as getStaffing()
-            if ($event->isRecurring()) {
-                $instances = $this->recurringEventService->generateInstances(
-                    $event->recurrence_rule,
-                    $event->start_datetime,
-                    now()->addMonths(3),
-                    10,
-                    $event->cancelled_occurrences ?? []
-                );
-
-                $nextOccurrence = collect($instances)->first(fn($instance) => $instance['start']->isFuture());
-                $targetOccurrenceDate = $nextOccurrence ? $nextOccurrence['start'] : $event->start_datetime;
-            } else {
-                $targetOccurrenceDate = $event->start_datetime;
-            }
+            $targetOccurrenceDate = $this->resolveTargetOccurrenceDate($event);
 
             $allStaffings = $event->staffings()->with('positions.bookedBy')->orderBy('order')->get();
 
-            $sectionTitles = [];
-            foreach ($allStaffings as $index => $section) {
-                $sectionNumber = $index + 1;
-                if ($sectionNumber <= 4) {
-                    $sectionTitles["section_{$sectionNumber}_title"] = $section->name;
-                }
-            }
-            for ($i = count($allStaffings) + 1; $i <= 4; $i++) {
-                $sectionTitles["section_{$i}_title"] = null;
-            }
+            $sectionTitles = $this->buildSectionTitles($allStaffings);
 
             $result[] = [
                 'id'         => $firstStaffing->id,
@@ -209,14 +169,12 @@ class ApiController extends Controller
             return response()->json(['error' => 'Staffing not found'], 404);
         }
 
-        // Get the first staffing (we'll return all staffings in the response)
         $staffing = $event->staffings()->with(['positions.bookedBy'])->orderBy('order')->first();
 
         if (!$staffing) {
             return response()->json(['error' => 'No staffing sections found'], 404);
         }
 
-        // Return the same format as getStaffing
         return $this->getStaffing($staffing->id);
     }
 
@@ -229,54 +187,18 @@ class ApiController extends Controller
         $staffing = \App\Models\Staffing::with(['event.calendar', 'positions.bookedBy'])->findOrFail($id);
         $event = $staffing->event;
 
-        // Calculate target occurrence date for position times
-        $targetOccurrenceDate = null;
-        if ($event->isRecurring()) {
-            $instances = $this->recurringEventService->generateInstances(
-                $event->recurrence_rule,
-                $event->start_datetime,
-                now()->addMonths(3),
-                10,
-                $event->cancelled_occurrences ?? []
-            );
+        $targetOccurrenceDate = $this->resolveTargetOccurrenceDate($event);
 
-            $nextOccurrence = collect($instances)->first(fn($instance) => $instance['start']->isFuture());
-            $targetOccurrenceDate = $nextOccurrence ? $nextOccurrence['start'] : $event->start_datetime;
-        } else {
-            $targetOccurrenceDate = $event->start_datetime;
-        }
-
-        // Get all staffings for this event ordered
         $allStaffings = $event->staffings()->with('positions.bookedBy')->orderBy('order')->get();
 
-        // Build section titles (max 4 sections)
-        $sectionTitles = [];
-        foreach ($allStaffings as $index => $section) {
-            $sectionNumber = $index + 1;
-            if ($sectionNumber <= 4) {
-                $sectionTitles["section_{$sectionNumber}_title"] = $section->name;
-            }
-        }
-        // Fill remaining sections with null
-        for ($i = count($allStaffings) + 1; $i <= 4; $i++) {
-            $sectionTitles["section_{$i}_title"] = null;
-        }
+        $sectionTitles = $this->buildSectionTitles($allStaffings);
 
-        // Flatten all positions with section numbers
         $allPositions = [];
         foreach ($allStaffings as $index => $section) {
             $sectionNumber = $index + 1;
             foreach ($section->positions->sortBy('order') as $position) {
-                // Combine occurrence date + position time (if position has specific times)
-                $startTime = null;
-                $endTime = null;
-
-                if ($position->start_time) {
-                    $startTime = substr($position->start_time, 0, 5); // "18:00" from "18:00:00"
-                }
-                if ($position->end_time) {
-                    $endTime = substr($position->end_time, 0, 5);
-                }
+                $startTime = $position->start_time ? substr($position->start_time, 0, 5) : null;
+                $endTime = $position->end_time ? substr($position->end_time, 0, 5) : null;
 
                 $allPositions[] = [
                     'id' => $position->id,
@@ -344,7 +266,6 @@ class ApiController extends Controller
 
         $staffing = \App\Models\Staffing::with('event')->findOrFail($id);
 
-        // Update the event's discord_staffing_message_id
         $staffing->event->update([
             'discord_staffing_message_id' => $validated['message_id'],
         ]);
@@ -368,10 +289,8 @@ class ApiController extends Controller
             'section' => 'nullable|integer',
         ]);
 
-        // Log the request for debugging
         \Log::info('Book request received', $validated);
 
-        // Find staffing by Discord message ID
         $event = \App\Models\Event::where('discord_staffing_message_id', $validated['message_id'])->first();
 
         if (!$event) {
@@ -381,21 +300,17 @@ class ApiController extends Controller
 
         \Log::info('Found event', ['event_id' => $event->id, 'title' => $event->title]);
 
-        // Find the position by callsign
         $query = \App\Models\StaffingPosition::whereHas('staffing', function ($q) use ($event) {
             $q->where('event_id', $event->id);
         })->where('position_id', $validated['position']);
 
-        // If section specified, match by staffing's position in the ordered list
         if (isset($validated['section'])) {
             \Log::info('Section specified', ['section' => $validated['section']]);
 
-            // Get all staffings ordered
             $staffings = $event->staffings()->orderBy('order')->get();
 
             \Log::info('Found staffings', ['count' => $staffings->count()]);
 
-            // Find the staffing at the specified section position (1-indexed)
             if (isset($staffings[$validated['section'] - 1])) {
                 $targetStaffing = $staffings[$validated['section'] - 1];
                 \Log::info('Target staffing', ['id' => $targetStaffing->id, 'name' => $targetStaffing->name]);
@@ -406,7 +321,6 @@ class ApiController extends Controller
             }
         }
 
-        // Debug: Log the SQL query
         \Log::info('Query SQL', ['sql' => $query->toSql(), 'bindings' => $query->getBindings()]);
 
         $position = $query->first();
@@ -424,47 +338,17 @@ class ApiController extends Controller
             return response()->json(['error' => 'Position already booked'], 422);
         }
 
-        // Store booking information without creating a User record
         $position->update([
             'vatsim_cid' => $validated['cid'],
             'discord_user_id' => $validated['discord_user_id'],
         ]);
 
-        // Create booking in Control Center
-        // Calculate the target occurrence date
-        $targetOccurrenceDate = null;
+        $targetOccurrenceDate = $this->resolveTargetOccurrenceDate($event);
 
-        if ($event->isRecurring()) {
-            // For recurring events, find next future occurrence
-            $instances = $this->recurringEventService->generateInstances(
-                $event->recurrence_rule,
-                $event->start_datetime,
-                now()->addMonths(3),
-                10,
-                $event->cancelled_occurrences ?? []
-            );
-
-            $nextOccurrence = collect($instances)->first(fn($instance) => $instance['start']->isFuture());
-
-            if ($nextOccurrence) {
-                $targetOccurrenceDate = $nextOccurrence['start'];
-            } else {
-                // No future occurrence found, use event date
-                $targetOccurrenceDate = $event->start_datetime;
-            }
-        } else {
-            // Non-recurring event, use event date directly
-            $targetOccurrenceDate = $event->start_datetime;
-        }
-
-        // Combine occurrence date with position time (or event time if position time not set)
-        // Position times are now stored as TIME only (e.g., "18:00:00")
         if ($position->start_time && $position->end_time) {
-            // Use occurrence date + position time
             $startDatetime = Carbon::parse($targetOccurrenceDate->format('Y-m-d') . ' ' . $position->start_time);
             $endDatetime = Carbon::parse($targetOccurrenceDate->format('Y-m-d') . ' ' . $position->end_time);
         } else {
-            // Use occurrence date + event time
             $startDatetime = $targetOccurrenceDate;
             $endDatetime = $targetOccurrenceDate->copy()->setTimeFrom($event->end_datetime);
         }
@@ -491,12 +375,10 @@ class ApiController extends Controller
 
         $bookingId = $this->controlCenterService->createBooking($bookingData);
 
-        // Store Control Center booking ID if successful
         if ($bookingId) {
             $position->update(['control_center_booking_id' => $bookingId]);
         }
 
-        // Dispatch job to notify bot (runs in background, doesn't block response)
         \App\Jobs\UpdateDiscordStaffingMessage::dispatch($event->id, 'updated');
 
         return response()->json([
@@ -517,14 +399,12 @@ class ApiController extends Controller
             'section' => 'nullable|integer',
         ]);
 
-        // Find staffing by Discord message ID
         $event = \App\Models\Event::where('discord_staffing_message_id', $validated['message_id'])->first();
 
         if (!$event) {
             return response()->json(['error' => 'Staffing not found'], 404);
         }
 
-        // Build query to find booked positions (check both user bookings and Discord bookings)
         $query = \App\Models\StaffingPosition::whereHas('staffing', function ($q) use ($event) {
             $q->where('event_id', $event->id);
         })->where(function ($q) {
@@ -537,17 +417,14 @@ class ApiController extends Controller
         }
 
         if (isset($validated['section'])) {
-            // Get all staffings ordered
             $staffings = $event->staffings()->orderBy('order')->get();
 
-            // Find the staffing at the specified section position (1-indexed)
             if (isset($staffings[$validated['section'] - 1])) {
                 $targetStaffing = $staffings[$validated['section'] - 1];
                 $query->where('staffing_id', $targetStaffing->id);
             }
         }
 
-        // Also filter by discord_user_id if provided
         if (isset($validated['discord_user_id'])) {
             $query->where('discord_user_id', $validated['discord_user_id']);
         }
@@ -559,7 +436,6 @@ class ApiController extends Controller
         }
 
         foreach ($positions as $position) {
-            // Delete booking from Control Center if booking ID exists
             if ($position->control_center_booking_id) {
                 $this->controlCenterService->deleteBooking($position->control_center_booking_id);
             }
@@ -572,7 +448,6 @@ class ApiController extends Controller
             ]);
         }
 
-        // Dispatch job to notify bot (runs in background, doesn't block response)
         \App\Jobs\UpdateDiscordStaffingMessage::dispatch($event->id, 'updated');
 
         return response()->json([
@@ -597,7 +472,6 @@ class ApiController extends Controller
             return response()->json(['error' => 'No Discord channel configured for this event'], 400);
         }
 
-        // Notify bot to create the staffing message
         $notificationService = app(\App\Services\DiscordBotNotificationService::class);
         $notificationService->notifyStaffingChanged($event, 'setup');
 
@@ -615,37 +489,21 @@ class ApiController extends Controller
         $staffing = \App\Models\Staffing::with(['event', 'positions'])->findOrFail($id);
         $event = $staffing->event;
 
-        // Only allow for recurring events
         if (!$event->isRecurring()) {
             return response()->json(['error' => 'Staffing reset is only available for recurring events'], 400);
         }
 
-        // Get all booked positions
         $bookedPositions = $event->staffings()
             ->with('positions')
             ->get()
-            ->flatMap(function ($staffing) {
-                return $staffing->positions;
-            })
-            ->filter(function ($position) {
-                return $position->isBooked();
-            });
+            ->flatMap(fn($staffing) => $staffing->positions)
+            ->filter(fn($position) => $position->isBooked());
 
-        // Delete Control Center bookings and clear position bookings
         foreach ($bookedPositions as $position) {
-            // Delete from Control Center if there's a booking ID
             if ($position->control_center_booking_id) {
-                try {
-                    $this->controlCenterService->deleteBooking($position->control_center_booking_id);
-                } catch (\Exception $e) {
-                    \Log::warning('Failed to delete Control Center booking during API reset', [
-                        'booking_id' => $position->control_center_booking_id,
-                        'error' => $e->getMessage(),
-                    ]);
-                }
+                $this->controlCenterService->deleteBooking($position->control_center_booking_id);
             }
 
-            // Clear all booking fields (position times remain unchanged - they're time-only now)
             $position->update([
                 'booked_by_user_id' => null,
                 'discord_user_id' => null,
@@ -654,7 +512,6 @@ class ApiController extends Controller
             ]);
         }
 
-        // Update Discord message to reflect the reset
         $notificationService = app(\App\Services\DiscordBotNotificationService::class);
         try {
             $notificationService->notifyStaffingChanged($event, 'updated');
@@ -673,6 +530,51 @@ class ApiController extends Controller
                 'channel_id' => $event->discord_staffing_channel_id,
             ],
         ], 200);
+    }
+
+    /**
+     * Resolve the target occurrence date for an event.
+     * For recurring events, returns the next future occurrence start datetime.
+     * Falls back to the event's own start_datetime if no future occurrence is found.
+     */
+    protected function resolveTargetOccurrenceDate(Event $event): Carbon
+    {
+        if (!$event->isRecurring()) {
+            return $event->start_datetime;
+        }
+
+        $instances = $this->recurringEventService->generateInstances(
+            $event->recurrence_rule,
+            $event->start_datetime,
+            now()->addMonths(3),
+            10,
+            $event->cancelled_occurrences ?? []
+        );
+
+        $nextOccurrence = collect($instances)->first(fn($instance) => $instance['start']->isFuture());
+
+        return $nextOccurrence ? $nextOccurrence['start'] : $event->start_datetime;
+    }
+
+    /**
+     * Build the section_1_title … section_4_title map from an ordered staffing collection.
+     */
+    protected function buildSectionTitles($allStaffings): array
+    {
+        $sectionTitles = [];
+
+        foreach ($allStaffings as $index => $section) {
+            $sectionNumber = $index + 1;
+            if ($sectionNumber <= 4) {
+                $sectionTitles["section_{$sectionNumber}_title"] = $section->name;
+            }
+        }
+
+        for ($i = count($allStaffings) + 1; $i <= 4; $i++) {
+            $sectionTitles["section_{$i}_title"] = null;
+        }
+
+        return $sectionTitles;
     }
 
     /**

--- a/app/Jobs/ResetStaffingForCompletedEvents.php
+++ b/app/Jobs/ResetStaffingForCompletedEvents.php
@@ -16,6 +16,8 @@ class ResetStaffingForCompletedEvents implements ShouldQueue
 {
     use Queueable;
 
+    private const MAX_HOURS_AFTER_END = 48;
+
     public function handle(
         EventService $eventService,
         ControlCenterService $controlCenterService,
@@ -23,33 +25,70 @@ class ResetStaffingForCompletedEvents implements ShouldQueue
     ): void {
         Log::info('Staffing Reset: Checking for completed occurrences...');
 
-        $recurringEvents = Event::whereNotNull('recurrence_rule')->get();
+        $recurringEvents = Event::whereNotNull('recurrence_rule')
+            ->whereNotNull('discord_staffing_channel_id')
+            ->get();
 
         foreach ($recurringEvents as $event) {
             try {
-                $lastOcc = $eventService->getLastEndedOccurrence($event);
-                if (!$lastOcc) continue;
-
-                $endedAt = Carbon::parse($lastOcc['end']);
-
-                // Reset criteria: Ended within 48h and not reset since that end time
-                $alreadyReset = $event->last_staffing_reset_at &&
-                    $event->last_staffing_reset_at->greaterThanOrEqualTo($endedAt);
-
-                if ($endedAt->isPast() && $endedAt->diffInHours(now()) <= 48 && !$alreadyReset) {
-                    $this->performReset($event, $controlCenterService, $discordBotService);
-
-                    $event->update(['last_staffing_reset_at' => now()]);
-                    Log::info("Staffing Reset: Completed for '{$event->title}'");
-                }
+                $this->processEvent($event, $eventService, $controlCenterService, $discordBotService);
             } catch (\Exception $e) {
-                Log::error("Staffing Reset: Failed for Event #{$event->id}: " . $e->getMessage());
+                Log::error("Staffing Reset: Failed for Event #{$event->id} '{$event->title}': " . $e->getMessage());
             }
         }
+
+        Log::info('Staffing Reset: Check complete.');
     }
 
-    private function performReset(Event $event, $controlCenter, $discordBot): void
-    {
+    private function processEvent(
+        Event $event,
+        EventService $eventService,
+        ControlCenterService $controlCenterService,
+        DiscordBotNotificationService $discordBotService
+    ): void {
+        $lastOcc = $eventService->getLastEndedOccurrence($event);
+
+        if (!$lastOcc) {
+            Log::debug("Staffing Reset: No ended occurrence found for '{$event->title}', skipping.");
+            return;
+        }
+
+        $endedAt = Carbon::parse($lastOcc['end']);
+
+        if ($endedAt->isFuture()) {
+            Log::debug("Staffing Reset: Last occurrence for '{$event->title}' hasn't ended yet, skipping.");
+            return;
+        }
+
+        $hoursSinceEnd = $endedAt->diffInHours(now());
+
+        if ($hoursSinceEnd > self::MAX_HOURS_AFTER_END) {
+            Log::debug("Staffing Reset: '{$event->title}' ended {$hoursSinceEnd}h ago, outside reset window.");
+            return;
+        }
+
+        $alreadyReset = $event->last_staffing_reset_at &&
+                        $event->last_staffing_reset_at->greaterThanOrEqualTo($endedAt);
+
+        if ($alreadyReset) {
+            Log::debug("Staffing Reset: '{$event->title}' already reset for occurrence ending at {$endedAt}.");
+            return;
+        }
+
+        Log::info("Staffing Reset: Resetting '{$event->title}' (occurrence ended at {$endedAt}, {$hoursSinceEnd}h ago).");
+
+        $this->performReset($event, $controlCenterService, $discordBotService);
+
+        $event->update(['last_staffing_reset_at' => $endedAt]);
+
+        Log::info("Staffing Reset: Successfully completed for '{$event->title}'.");
+    }
+
+    private function performReset(
+        Event $event,
+        ControlCenterService $controlCenter,
+        DiscordBotNotificationService $discordBot
+    ): void {
         DB::transaction(function () use ($event, $controlCenter, $discordBot) {
             $staffings = $event->staffings()->with('positions')->get();
 
@@ -59,20 +98,20 @@ class ResetStaffingForCompletedEvents implements ShouldQueue
                         try {
                             $controlCenter->deleteBooking($position->control_center_booking_id);
                         } catch (\Exception $e) {
-                            Log::warning("CC Delete error: " . $e->getMessage());
+                            Log::warning("Staffing Reset: Failed to delete CC booking #{$position->control_center_booking_id}: " . $e->getMessage());
                         }
                     }
 
                     $position->update([
-                        'booked_by_user_id' => null,
-                        'discord_user_id' => null,
-                        'vatsim_cid' => null,
+                        'booked_by_user_id'        => null,
+                        'discord_user_id'           => null,
+                        'vatsim_cid'                => null,
                         'control_center_booking_id' => null,
                     ]);
                 }
             }
 
-            $discordBot->notifyStaffingChanged($event, 'updated');
+            $discordBot->notifyStaffingChanged($event, 'reset');
         });
     }
 }

--- a/app/Jobs/ResetStaffingForCompletedEvents.php
+++ b/app/Jobs/ResetStaffingForCompletedEvents.php
@@ -89,29 +89,45 @@ class ResetStaffingForCompletedEvents implements ShouldQueue
         ControlCenterService $controlCenter,
         DiscordBotNotificationService $discordBot
     ): void {
-        DB::transaction(function () use ($event, $controlCenter, $discordBot) {
-            $staffings = $event->staffings()->with('positions')->get();
+        // Collect Control Center booking IDs before touching the DB so we know
+        // exactly what to clean up externally, regardless of what happens later.
+        $controlCenterBookingIds = $event->staffings()
+            ->with('positions')
+            ->get()
+            ->flatMap(fn($staffing) => $staffing->positions)
+            ->filter(fn($position) => $position->isBooked() && $position->control_center_booking_id)
+            ->pluck('control_center_booking_id')
+            ->all();
 
-            foreach ($staffings as $staffing) {
-                foreach ($staffing->positions as $position) {
-                    if ($position->control_center_booking_id) {
-                        try {
-                            $controlCenter->deleteBooking($position->control_center_booking_id);
-                        } catch (\Exception $e) {
-                            Log::warning("Staffing Reset: Failed to delete CC booking #{$position->control_center_booking_id}: " . $e->getMessage());
-                        }
-                    }
-
-                    $position->update([
+        // Clear all booking fields in a single, focused DB transaction with no
+        // external side-effects so the transaction stays short and fully rollbackable.
+        DB::transaction(function () use ($event) {
+            $event->staffings()->with('positions')->get()
+                ->each(function ($staffing) {
+                    $staffing->positions->each(fn($position) => $position->update([
                         'booked_by_user_id'        => null,
                         'discord_user_id'           => null,
                         'vatsim_cid'                => null,
                         'control_center_booking_id' => null,
-                    ]);
-                }
-            }
-
-            $discordBot->notifyStaffingChanged($event, 'reset');
+                    ]));
+                });
         });
+
+        // External calls happen after the DB transaction has committed so that:
+        // 1. A failed network call cannot cause a DB rollback that leaves data inconsistent.
+        // 2. The transaction is not held open while waiting on slow HTTP responses.
+        foreach ($controlCenterBookingIds as $bookingId) {
+            try {
+                $controlCenter->deleteBooking($bookingId);
+            } catch (\Exception $e) {
+                Log::warning("Staffing Reset: Failed to delete CC booking #{$bookingId}: " . $e->getMessage());
+            }
+        }
+
+        try {
+            $discordBot->notifyStaffingChanged($event, 'reset');
+        } catch (\Exception $e) {
+            Log::warning("Staffing Reset: Failed to notify Discord for Event #{$event->id}: " . $e->getMessage());
+        }
     }
 }

--- a/app/Jobs/ResetStaffingForCompletedEvents.php
+++ b/app/Jobs/ResetStaffingForCompletedEvents.php
@@ -33,12 +33,12 @@ class ResetStaffingForCompletedEvents implements ShouldQueue
                 $endedAt = Carbon::parse($lastOcc['end']);
 
                 // Reset criteria: Ended within 48h and not reset since that end time
-                $alreadyReset = $event->last_staffing_reset_at && 
-                                $event->last_staffing_reset_at->greaterThanOrEqualTo($endedAt);
+                $alreadyReset = $event->last_staffing_reset_at &&
+                    $event->last_staffing_reset_at->greaterThanOrEqualTo($endedAt);
 
-                if ($endedAt->diffInHours(now()) <= 48 && !$alreadyReset) {
+                if ($endedAt->isPast() && $endedAt->diffInHours(now()) <= 48 && !$alreadyReset) {
                     $this->performReset($event, $controlCenterService, $discordBotService);
-                    
+
                     $event->update(['last_staffing_reset_at' => now()]);
                     Log::info("Staffing Reset: Completed for '{$event->title}'");
                 }

--- a/tests/Feature/ResetStaffingForCompletedEventsTest.php
+++ b/tests/Feature/ResetStaffingForCompletedEventsTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\ResetStaffingForCompletedEvents;
+use App\Models\Event;
+use App\Models\Staffing;
+use App\Models\StaffingPosition;
+use App\Services\ControlCenterService;
+use App\Services\DiscordBotNotificationService;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class ResetStaffingForCompletedEventsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ControlCenterService $controlCenter;
+    private DiscordBotNotificationService $discordBot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->controlCenter = Mockery::mock(ControlCenterService::class);
+        $this->discordBot = Mockery::mock(DiscordBotNotificationService::class);
+
+        $this->app->instance(ControlCenterService::class, $this->controlCenter);
+        $this->app->instance(DiscordBotNotificationService::class, $this->discordBot);
+    }
+
+    /** @test */
+    public function it_resets_staffing_when_occurrence_has_just_ended(): void
+    {
+        $event = $this->createRecurringEvent(
+            start: now()->subHours(3),
+            end: now()->subHour(),
+        );
+
+        $position = $this->createBookedPosition($event);
+
+        $this->discordBot->shouldReceive('notifyStaffingChanged')
+            ->once()
+            ->with(Mockery::on(fn($e) => $e->id === $event->id), 'reset');
+
+        $this->controlCenter->shouldReceive('deleteBooking')
+            ->once()
+            ->with(1);
+
+        $this->dispatchJob();
+
+        $position->refresh();
+
+        $this->assertNull($position->booked_by_user_id);
+        $this->assertNull($position->discord_user_id);
+        $this->assertNull($position->vatsim_cid);
+        $this->assertNull($position->control_center_booking_id);
+        $this->assertNotNull($event->fresh()->last_staffing_reset_at);
+    }
+
+    /** @test */
+    public function it_does_not_reset_if_occurrence_has_not_ended_yet(): void
+    {
+        $event = $this->createRecurringEvent(
+            start: now()->subHour(),
+            end: now()->addHour(),
+        );
+
+        $this->createBookedPosition($event);
+
+        $this->discordBot->shouldNotReceive('notifyStaffingChanged');
+        $this->controlCenter->shouldNotReceive('deleteBooking');
+
+        $this->dispatchJob();
+
+        $this->assertNull($event->fresh()->last_staffing_reset_at);
+    }
+
+    /** @test */
+    public function it_does_not_reset_if_already_reset_for_this_occurrence(): void
+    {
+        $occurrenceEnd = now()->subHours(2);
+
+        $event = $this->createRecurringEvent(
+            start: now()->subHours(4),
+            end: $occurrenceEnd,
+            lastResetAt: $occurrenceEnd,
+        );
+
+        $this->createBookedPosition($event);
+
+        $this->discordBot->shouldNotReceive('notifyStaffingChanged');
+        $this->controlCenter->shouldNotReceive('deleteBooking');
+
+        $this->dispatchJob();
+    }
+
+    /** @test */
+    public function it_does_not_reset_if_outside_48h_window(): void
+    {
+        $event = $this->createRecurringEvent(
+            start: now()->subHours(72), // base occurrence well outside window
+            end: now()->subHours(49),   // ended 49h ago, outside 48h window
+        );
+
+        $this->createBookedPosition($event);
+
+        $this->discordBot->shouldNotReceive('notifyStaffingChanged');
+        $this->controlCenter->shouldNotReceive('deleteBooking');
+
+        $this->dispatchJob();
+    }
+
+    /** @test */
+    public function it_stores_occurrence_end_time_not_current_time_after_reset(): void
+    {
+        $occurrenceEnd = now()->subHours(2)->startOfMinute();
+
+        $event = $this->createRecurringEvent(
+            start: now()->subHours(4),
+            end: $occurrenceEnd,
+        );
+
+        $this->createBookedPosition($event);
+
+        $this->discordBot->shouldReceive('notifyStaffingChanged')->once();
+        $this->controlCenter->shouldReceive('deleteBooking')->once()->with(1);
+
+        $this->dispatchJob();
+
+        $resetAt = $event->fresh()->last_staffing_reset_at->startOfMinute();
+
+        $this->assertTrue($resetAt->equalTo($occurrenceEnd));
+    }
+
+    /** @test */
+    public function it_skips_events_without_discord_channel(): void
+    {
+        $event = $this->createRecurringEvent(
+            start: now()->subHours(3),
+            end: now()->subHour(),
+            discordChannelId: null,
+        );
+
+        // Force null in case the factory has a default
+        $event->update(['discord_staffing_channel_id' => null]);
+
+        $this->createBookedPosition($event);
+
+        $this->discordBot->shouldNotReceive('notifyStaffingChanged');
+        $this->controlCenter->shouldNotReceive('deleteBooking');
+
+        $this->dispatchJob();
+    }
+
+    /** @test */
+    public function it_continues_processing_other_events_if_one_fails(): void
+    {
+        $failingEvent = $this->createRecurringEvent(
+            start: now()->subHours(3),
+            end: now()->subHour(),
+        );
+
+        $successEvent = $this->createRecurringEvent(
+            start: now()->subHours(3),
+            end: now()->subHour(),
+        );
+
+        $this->createBookedPosition($failingEvent);
+        $this->createBookedPosition($successEvent);
+
+        $this->discordBot->shouldReceive('notifyStaffingChanged')
+            ->twice()
+            ->andThrow(new \Exception('Discord unavailable'));
+
+        $this->controlCenter->shouldReceive('deleteBooking')->with(1)->andReturn(true);
+
+        $this->dispatchJob();
+    }
+
+    /** @test */
+    public function it_handles_failed_control_center_deletion_gracefully(): void
+    {
+        $event = $this->createRecurringEvent(
+            start: now()->subHours(3),
+            end: now()->subHour(),
+        );
+
+        $this->createBookedPosition($event);
+
+        $this->controlCenter->shouldReceive('deleteBooking')
+            ->once()
+            ->with(1)
+            ->andThrow(new \Exception('CC unavailable'));
+
+        $this->discordBot->shouldReceive('notifyStaffingChanged')
+            ->once()
+            ->with(Mockery::any(), 'reset');
+
+        $this->dispatchJob();
+
+        $this->assertNotNull($event->fresh()->last_staffing_reset_at);
+    }
+
+    // --- Helpers ---
+
+    private function dispatchJob(): void
+    {
+        app(ResetStaffingForCompletedEvents::class)->handle(
+            app(\App\Services\EventService::class),
+            $this->controlCenter,
+            $this->discordBot,
+        );
+    }
+
+    private function createRecurringEvent(
+        Carbon $start,
+        Carbon $end,
+        ?Carbon $lastResetAt = null,
+        ?string $discordChannelId = null,
+    ): Event {
+        return Event::factory()->create([
+            'start_datetime'              => $start,
+            'end_datetime'                => $end,
+            'recurrence_rule'             => 'FREQ=WEEKLY;BYDAY=SA',
+            'discord_staffing_channel_id' => $discordChannelId ?? (string) rand(100000000, 999999999),
+            'last_staffing_reset_at'      => $lastResetAt,
+        ]);
+    }
+
+    private function createBookedPosition(Event $event): StaffingPosition
+    {
+        $staffing = Staffing::factory()->create(['event_id' => $event->id]);
+
+        return StaffingPosition::factory()->create([
+            'staffing_id'               => $staffing->id,
+            'booked_by_user_id'         => 1,
+            'discord_user_id'           => '987654321',
+            'vatsim_cid'                => '1234567',
+            'control_center_booking_id' => 1,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Update automatic staffing reset logic for recurring events and ensure staffing event dates align with the correct recurrence occurrence.

Bug Fixes:
- Fix automatic staffing resets to only run once per completed occurrence within a limited time window and to skip ineligible events.
- Ensure event dates used in staffing APIs are based on the relevant recurring occurrence instead of the base event dates.

Enhancements:
- Improve logging and error handling around staffing reset processing and Control Center booking cleanup.
- Refactor staffing reset job into smaller methods for clearer flow and maintainability.

Tests:
- Add feature tests covering staffing reset timing, idempotency, error handling, and Discord/Control Center interaction behavior.